### PR TITLE
perf: 下楼事件确认楼层变化之后才结束

### DIFF
--- a/agent/action/fight/fightUtils.py
+++ b/agent/action/fight/fightUtils.py
@@ -1036,7 +1036,24 @@ def handle_dragon_event(map_str: str, context: Context):
         logger.info("神龙带肥家lo~")
 
 
+def handle_getlayernumber_event(context: Context):
+    context.run_task("Fight_ReturnMainWindow")
+    tempLayers = -1
+    while tempLayers <= 0 and (
+        RunResult := context.run_recognition(
+            "Fight_CheckLayer",
+            context.tasker.controller.post_screencap().wait().get(),
+        )
+    ):
+        tempLayers = extract_num_layer(RunResult.best_result.text)
+        if context.tasker.stopping:
+            logger.info("检测到停止任务, 开始退出agent")
+            return -1
+    return tempLayers
+
+
 def handle_downstair_event(context: Context):
+    temp_layer = handle_getlayernumber_event(context)
     recoDetail = context.run_task("Fight_OpenedDoor")
     if not recoDetail.nodes and context.run_recognition(
         "FindKeyHole", context.tasker.controller.post_screencap().wait().get()
@@ -1055,6 +1072,13 @@ def handle_downstair_event(context: Context):
 
         logger.info("冒险者大人已找到钥匙捏，继续探索")
         context.run_task("Fight_OpenedDoor")
+    # 确认层数更换再返回
+    for _ in range(5):
+        current_layer = handle_getlayernumber_event(context)
+        if temp_layer != current_layer and current_layer != -1:
+            return True
+        time.sleep(1)
+    logger.info("由于未知原因, 层数未改变，可能在夹层中")
     return True
 
 

--- a/agent/action/fight/mars101.py
+++ b/agent/action/fight/mars101.py
@@ -45,18 +45,7 @@ class Mars101(CustomAction):
         logger.info(f"当前层数: {self.layers}, 进入地图初始化")
 
     def Check_CurrentLayers(self, context: Context):
-        context.run_task("Fight_ReturnMainWindow")
-        tempLayers = -1
-        while tempLayers <= 0 and (
-            RunResult := context.run_recognition(
-                "Fight_CheckLayer",
-                context.tasker.controller.post_screencap().wait().get(),
-            )
-        ):
-            tempLayers = fightUtils.extract_num_layer(RunResult.best_result.text)
-            if context.tasker.stopping:
-                logger.info("检测到停止任务, 开始退出agent")
-                return False
+        tempLayers = fightUtils.handle_getlayernumber_event(context)
         self.layers = tempLayers
         return True
 
@@ -320,8 +309,6 @@ class Mars101(CustomAction):
     def handle_preLayers_event(self, context: Context):
         self.handle_android_skill_event(context)
         self.Check_DefaultEquipment(context)
-        self.Check_DefaultTitle(context)
-
         return True
 
     def handle_perfect_event(self, context: Context):
@@ -578,7 +565,7 @@ class Mars101(CustomAction):
         self.isAutoPickup = True
 
     def handle_postLayers_event(self, context: Context):
-        time.sleep(2)
+        time.sleep(1)
         self.handle_perfect_event(context)
         fightUtils.handle_dragon_event("马尔斯", context)
         self.Check_DefaultStatus(context)
@@ -590,6 +577,8 @@ class Mars101(CustomAction):
         self.handle_MarsRuinsShop_event(context, image)
         self.handle_MarsReward_event(context, image)
         self.handle_MarsExchangeShop_event(context, image)
+        # 点称号挪到战后，确保购买战利品有足够的探索点
+        self.Check_DefaultTitle(context)
         if not self.handle_SpecialLayer_event(context, image):
             # 如果卡剧情(离开),则返回False, 重新清理该层
             return False

--- a/assets/resource/base/pipeline/fight/mars101.json
+++ b/assets/resource/base/pipeline/fight/mars101.json
@@ -94,6 +94,7 @@
         "post_delay": 1000,
         "timeout": 2000,
         "next": [
+            "MarsReward_OpenAll",
             "MarsReward_Select",
             "MarsReward_Open",
             "Mars_Inter_Confirm_Fail"
@@ -122,6 +123,20 @@
         "recognition": "TemplateMatch",
         "template": [
             "fight/Mars/MarsReward_Open.png",
+            "fight/Mars/MarsReward_OpenAll.png"
+        ],
+        "roi": [
+            35,
+            463,
+            662,
+            489
+        ],
+        "action": "Click",
+        "timeout": 2000
+    },
+    "MarsReward_OpenAll": {
+        "recognition": "TemplateMatch",
+        "template": [
             "fight/Mars/MarsReward_OpenAll.png"
         ],
         "roi": [


### PR DESCRIPTION
1. 下楼事件确认楼层变化之后才结束
2. 点称号移到战后事件，确保在任何情况都有足够的探索点购买特殊战利品
3. 优化reward事件的流程