### PR TITLE
fix: 修复联盟领取奖励ROI范围

### DIFF
--- a/assets/resource/base/pipeline/reward.json
+++ b/assets/resource/base/pipeline/reward.json
@@ -52,10 +52,10 @@
         "recognition": "OCR",
         "expected": "联盟礼包",
         "roi": [
-            145,
-            728,
-            440,
-            190
+            107,
+            484,
+            423,
+            470
         ],
         "post_delay": 1000,
         "timeout": 2000,
@@ -101,10 +101,10 @@
         "recognition": "OCR",
         "expected": "联盟任务",
         "roi": [
-            145,
-            728,
-            440,
-            190
+            107,
+            484,
+            423,
+            470
         ],
         "post_delay": 1000,
         "timeout": 2000,


### PR DESCRIPTION
<img width="720" height="1280" alt="image" src="https://github.com/user-attachments/assets/1d9d15f3-bc28-4d9e-9343-c3503f3be400" />


修复前

存在部分没有联盟公告的联盟，导致联盟礼包与联盟任务错位

由原来的145,728,110,190，更正为107,484,423,470

修复后

<img width="720" height="1280" alt="image" src="https://github.com/user-attachments/assets/f4d375db-a50f-4ee8-90da-c00d4099e340" />