### PR TITLE
chore: 扩展黑装备功能支持多种装备套，调整神龙许愿消息推送逻辑

### DIFF
--- a/agent/action/divineForgeLand/someTrick.py
+++ b/agent/action/divineForgeLand/someTrick.py
@@ -33,15 +33,15 @@ class SaveLoad_little(CustomAction):
 
 @AgentServer.custom_action("GoDownstairsTrick_Test")
 class GoDownstairsTrick_Test(CustomAction):
-    # 这里检查永恒套装
-    def CheckEternalSuit(self, context: Context, image, tartget_equipment_path):
+    # 这里检查套装
+    def CheckEternalSuit(self, context: Context, image, target_equipment_path):
         checkEternalDetail = context.run_recognition(
             "CheckEternalSuit",
             image,
             pipeline_override={
                 "CheckEternalSuit": {
                     "recognition": "TemplateMatch",
-                    "template": [tartget_equipment_path],
+                    "template": [target_equipment_path],
                     "roi": [30, 68, 665, 590],
                     "threshold": 0.7,
                 }
@@ -55,90 +55,99 @@ class GoDownstairsTrick_Test(CustomAction):
         context: Context,
         argv: CustomAction.RunArg,
     ) -> CustomAction.RunResult:
-        # 这里检查永恒套装
-        logger.info("黑永恒 检查是否有目标装备")
+        equipment = json.loads(argv.custom_action_param)["equipment"]
+        equipmentsList: dict = {
+            "永恒套": {
+                "永恒腕轮": "equipments/5level/永恒腕轮.png",
+                "永恒披风": "equipments/5level/永恒披风.png",
+                "永恒王冠": "equipments/5level/永恒王冠.png",
+                "永恒之球": "equipments/5level/永恒之球.png",
+            },
+            "龙鳞套": {
+                "龙鳞护腕": "equipments/4level/龙鳞护腕.png",
+                "龙鳞甲": "equipments/4level/龙鳞甲.png",
+                "龙鳞盔": "equipments/4level/龙鳞盔.png",
+                "龙鳞腰带": "equipments/4level/龙鳞腰带.png",
+            },
+            "神谕套": {
+                "神谕手套": "equipments/5level/神谕手套.png",
+                "神谕之甲": "equipments/5level/神谕之甲.png",
+                "神谕之盔": "equipments/5level/神谕之盔.png",
+                "神谕束带": "equipments/5level/神谕束带.png",
+            },
+            "魔导士套": {
+                "魔导士挂坠": "equipments/5level/魔导士挂坠.png",
+                "魔导士斗篷": "equipments/5level/魔导士斗篷.png",
+                "魔导士之靴": "equipments/5level/魔导士之靴.png",
+                "魔导士指轮": "equipments/5level/魔导士指轮.png",
+            },
+            "骑士套": {
+                "骑士手套": "equipments/1level/骑士手套.png",
+                "骑士盔甲": "equipments/1level/骑士盔甲.png",
+                "骑士头盔": "equipments/1level/骑士头盔.png",
+                "骑士腰带": "equipments/1level/骑士腰带.png",
+            },
+            "学徒套": {
+                "学徒项链": "equipments/1level/学徒项链.png",
+                "学徒披风": "equipments/1level/学徒披风.png",
+                "学徒鞋子": "equipments/1level/学徒鞋子.png",
+                "学徒戒指": "equipments/1level/学徒戒指.png",
+            },
+        }
+        # 这里检查套装
+        logger.info(f"黑装备-{equipment} 检查是否有目标装备")
         context.run_task("OpenEquipmentPackage")
         img = context.tasker.controller.post_screencap().wait().get()
-        before_gloves = self.CheckEternalSuit(
-            context, img, "equipments/5level/永恒腕轮.png"
-        )
-        before_cloak = self.CheckEternalSuit(
-            context, img, "equipments/5level/永恒披风.png"
-        )
-        before_helmet = self.CheckEternalSuit(
-            context, img, "equipments/5level/永恒王冠.png"
-        )
-        before_weapon = self.CheckEternalSuit(
-            context, img, "equipments/5level/永恒之球.png"
-        )
-        context.run_task("BackText")
+        targetList: dict = {}
+        for key in equipmentsList[equipment]:
+            targetList[key] = self.CheckEternalSuit(
+                context, img, equipmentsList[equipment][key]
+            )
 
+        context.run_task("BackText")
+        logger.info(f"targetList: {targetList}")
         for i in range(101):
             if context.tasker.stopping:
                 logger.info("检测到停止任务, 开始退出agent")
                 return CustomAction.RunResult(success=False)
 
-            logger.info(f"黑永恒第{i}次尝试")
+            logger.info(f"黑装备-{equipment} 第{ i+1 }次尝试")
             context.run_task("Save_Status")
             context.run_task("StartAppV2")
             context.run_task("Fight_OpenedDoor")
             fightUtils.cast_magic("土", "地震术", context)
             context.run_task("KillChestMonster")
 
-            logger.info("黑永恒 检查是否黑到目标装备")
+            logger.info(f"黑装备-{equipment} 检查是否黑到目标装备")
             context.run_task("OpenEquipmentPackage")
             time.sleep(1)
             img_2 = context.tasker.controller.post_screencap().wait().get()
             temp = 0
-            if not before_gloves:
-                after_gloves = self.CheckEternalSuit(
-                    context, img_2, "equipments/5level/永恒腕轮.png"
-                )
-                if after_gloves:
-                    temp += 1
-            else:
-                after_gloves = before_gloves
-            if not before_cloak:
-                after_cloak = self.CheckEternalSuit(
-                    context, img_2, "equipments/5level/永恒披风.png"
-                )
-                if after_cloak:
-                    temp += 1
-            else:
-                after_cloak = before_cloak
-            if not before_helmet:
-                after_helmet = self.CheckEternalSuit(
-                    context, img_2, "equipments/5level/永恒王冠.png"
-                )
-                if after_helmet:
-                    temp += 1
-            else:
-                after_helmet = before_helmet
-            if not before_weapon:
-                after_weapon = self.CheckEternalSuit(
-                    context, img_2, "equipments/5level/永恒之球.png"
-                )
-                if after_weapon:
-                    temp += 1
-            else:
-                after_weapon = before_weapon
+            for key in targetList:
+                if not targetList[key]:
+                    afterResult = self.CheckEternalSuit(
+                        context, img_2, equipmentsList[equipment][key]
+                    )
+                    if afterResult:
+                        logger.info(f"黑装备-{equipment} 检查到目标装备-{key}")
+                        temp += 1
 
             context.run_task("BackText")
 
             if temp >= 1:
-                logger.info("黑永恒成功，恢复网络，可以暂离保存")
+                logger.info(f"黑装备-{equipment} 成功，恢复网络，可以暂离保存")
                 context.run_task("StopAppV2")
                 time.sleep(1)
                 context.run_task("Save_Status")
                 return CustomAction.RunResult(success=True)
 
             else:
-                logger.info("黑永恒失败, 小SL然后联网进行下一次尝试")
+                logger.info(f"黑装备-{equipment} 失败, 小SL然后联网进行下一次尝试")
                 context.run_task("LogoutGame")
                 context.run_task("StopAppV2")
                 context.run_task("ReturnMaze")
 
-        logger.warning("黑永恒失败")
+        logger.warning(f"黑装备-{equipment} 失败")
         return CustomAction.RunResult(success=False)
 
 

--- a/agent/action/fight/fightUtils.py
+++ b/agent/action/fight/fightUtils.py
@@ -859,7 +859,7 @@ def dragonwish(targetWish: str, context: Context):
             image = context.tasker.controller.post_screencap().wait().get()
             if context.run_recognition("ConfirmButton_500ms", image):
                 context.run_task("ConfirmButton_500ms")
-
+            send_message("MaaGB", "冒险者大人，今日钻石已领肥家咯~")
         elif min_index_wish in ["我要大量的矿石"]:
             # 等待地图加载
             time.sleep(10)
@@ -1034,7 +1034,6 @@ def handle_dragon_event(map_str: str, context: Context):
         logger.info("是神龙,俺,俺们有救了！！！")
         dragonwish(map_str, context)
         logger.info("神龙带肥家lo~")
-        send_message(f"MaaGB", "是神龙,俺,俺们有救了！！！")
 
 
 def handle_currentlayer_event(context: Context):

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -312,7 +312,8 @@
             "option": [
                 "选择神锻任务",
                 "接受星光",
-                "目标日光数及自动熔设定"
+                "目标日光数及自动熔设定",
+                "黑装备类型"
             ],
             "doc": [
                 "## 神锻系列说明",
@@ -321,9 +322,10 @@
                 "   - **接受星光**: 选择黑日光任务时，接受星光奖励",
                 "   - **目标日光数及自动熔设定**: 选择神锻测序——融序任务时，设置目标日光数及自动熔设定",
                 "",
-                "▶️ **黑永恒**  ",
+                "▶️ **黑装备**  ",
                 "   - 需要V2ray应用并配置好飞行模式  ",
                 "   - 需要一张地震术,9/19层最好穿上铠甲来保证地震术可以翻开所有地板  ",
+                "   - 目前支持永恒套、神谕套、龙鳞套、魔导士套、骑士套及学徒套，默认为永恒套，需要其他的记得在选项中选择",
                 "   - 下楼之前，确保你需要黑的位置，即黑永恒时头,手,武器以及披风位置, 不要装备除永恒套的其他装备  ",
                 "",
                 "▶️ **黑日光**  ",
@@ -401,7 +403,7 @@
                     }
                 },
                 {
-                    "name": "黑永恒",
+                    "name": "黑装备",
                     "pipeline_override": {
                         "DivineForgeLand_Start": {
                             "next": "GoDownstairsTrick"
@@ -804,6 +806,71 @@
                             "custom_action_param": {
                                 "target_sunlight": 21,
                                 "auto_melt": 6
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "黑装备类型":{
+            "default_case": "永恒套",
+            "cases": [
+                {
+                    "name":"永恒套",
+                    "pipeline_override": {
+                        "GoDownstairsTrick": {
+                            "custom_action_param": {
+                                "equipment": "永恒套"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "龙鳞套",
+                    "pipeline_override": {
+                        "GoDownstairsTrick": {
+                            "custom_action_param": {
+                                "equipment": "龙鳞套"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "神谕套",
+                    "pipeline_override": {
+                        "GoDownstairsTrick": {
+                            "custom_action_param": {
+                                "equipment": "神谕套"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "魔导士套",
+                    "pipeline_override": {
+                        "GoDownstairsTrick": {
+                            "custom_action_param": {
+                                "equipment": "魔导士套"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "骑士套",
+                    "pipeline_override": {
+                        "GoDownstairsTrick": {
+                            "custom_action_param": {
+                                "equipment": "骑士套"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "学徒套",
+                    "pipeline_override": {
+                        "GoDownstairsTrick": {
+                            "custom_action_param": {
+                                "equipment": "学徒套"
                             }
                         }
                     }


### PR DESCRIPTION
chore: 扩展黑装备功能支持多种装备套
- 新增龙鳞套、神谕套、魔导士套、骑士套和学徒套的支持
- 优化代码结构，提高可维护性和可扩展性
- 更新用户界面和文档，增加黑装备类型选项

chore: 调整神龙许愿消息推送逻辑
- 在神龙许愿后得到钻石后，增加消息推送
- 移除神龙事件开始时的消息推送