### PR TITLE
perf: 探索废墟默认全部舰队，不再受选择出战舰队数量影响；添加任务停止检测机制

### DIFF
--- a/assets/resource/base/pipeline/fight/time_space_domain.json
+++ b/assets/resource/base/pipeline/fight/time_space_domain.json
@@ -230,13 +230,10 @@
         ]
     },
     "TSD_SelectFreeFleetInList": {
-        "recognition": "TemplateMatch",
-        "template": "fight/time_space_domain/fleetFreeInList.png",
+        "recognition": "OCR",
+        "expected": ["深渊"],
         "roi": [
-            37,
-            167,
-            102,
-            77
+            44, 164, 627, 537
         ],
         "action": "Click",
         "post_delay": 1500


### PR DESCRIPTION
- 新增默认舰队顺序和当前可用舰队列表属性
- 优化舰队识别方式，使用OCR替代模板匹配
- 支持根据任务类型切换使用的舰队列表
- 添加任务停止检测机制，提升运行安全性
- 调整探索任务中舰队轮换逻辑，确保顺序正确更新