### PR TITLE
docs: 更新外部通知文档中的 qmsg 图片链接

### DIFF
--- a/docs/zh_cn/manual/外部通知.md
+++ b/docs/zh_cn/manual/外部通知.md
@@ -76,7 +76,7 @@ MFAAvalonia 内置了外部通知功能，允许用户在运行结束时向已�
 ### Qmsg
 
 参照Qsmg的官方[文档地址](https://qmsg.zendee.cn/doc/)，选择机器人并**添加qq好友**，获取自己的**key**，然后将自己的qq加入列表，如下图所示：
-![qmsg管理台设置](https://private-user-images.githubusercontent.com/19379277/472881680-7466d7e0-82ea-454e-923b-c16170de72a5.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTM5NTAwNDYsIm5iZiI6MTc1Mzk0OTc0NiwicGF0aCI6Ii8xOTM3OTI3Ny80NzI4ODE2ODAtNzQ2NmQ3ZTAtODJlYS00NTRlLTkyM2ItYzE2MTcwZGU3MmE1LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA3MzElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNzMxVDA4MTU0NlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTJiY2NlMWU1Y2M5OWUxNDcyNjY1MDNkODQ5NDkxMjVmYzFmNzNjM2Q5Njk5ZDBmNTI4YzU4NzljMmMxM2VkYjgmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.oflSOqJmWDCjkRNvsDV9lv5eASOy922ddgEJ1PK8tpg)
+![qmsg管理台设置](https://i.imgs.ovh/2025/10/29/7KYien.png)
 
 MFAAvalonia 配置：
 | 选项                                                         | 值                                                           |


### PR DESCRIPTION
将 qmsg 管理台设置的图片链接替换为新的图床地址，确保文档中图片正常显示。