### PR TITLE
fix: 修复check_magic找不到卷轴的问题，Mars卡休息室增加提醒

### DIFF
--- a/agent/action/fight/fightUtils.py
+++ b/agent/action/fight/fightUtils.py
@@ -157,7 +157,13 @@ def check_magic(Type: str, MagicName: str, context: Context):
         "Fight_Magic_Elemental",
         pipeline_override={
             "Fight_Magic_Elemental": {
-                "next": [MagicType[Type], "Fight_FindDragon", "Fight_FindRespawn"]
+                "next": [
+                    MagicType[Type],
+                    "Fight_FindDragon",
+                    "Fight_FindRespawn",
+                    "[JumpBack]Fight_SkillPack_Type",
+                    "[JumpBack]Fight_SkillPack_Open",
+                ]
             }
         },
     )

--- a/agent/action/fight/mars101.py
+++ b/agent/action/fight/mars101.py
@@ -1542,6 +1542,7 @@ class Mars101(CustomAction):
 
     def leaveSpecialLayer(self, context: Context):
         context.run_task("Fight_ReturnMainWindow")
+        count = 0
         for _ in range(10):
             if context.run_recognition(
                 "Mars_LeaveSpecialLayer",
@@ -1554,6 +1555,12 @@ class Mars101(CustomAction):
             context.tasker.controller.post_screencap().wait().get(),
         ).hit:
             time.sleep(1)
+            if count < 10:
+                context.run_task("Mars_LeaveSpecialLayer")
+                count += 1
+            else:
+                send_message("MaaGB", "自动离开休息室失败10次，请冒险者大大手动离开!")
+                break
         logger.info("离开休息室")
         return True
 


### PR DESCRIPTION
## Summary by Sourcery

Update fight flow to better recover from failed magic checks and improve robustness when leaving Mars rest area.

Bug Fixes:
- Ensure magic checks correctly fall back to skill pack flows when scrolls are not found.
- Retry leaving the Mars rest area up to 10 times and notify the player if automatic exit repeatedly fails.