### PR TITLE
feat: Mars手动结算开关调整为结算方式选择框，支持自动结算/九柱暂离/清怪暂离，按需选择即可。

### DIFF
--- a/agent/action/fight/mars101.py
+++ b/agent/action/fight/mars101.py
@@ -570,10 +570,10 @@ class Mars101(CustomAction):
                 "param"
             ]["expected"][0]
         ).lower() == "true"
-        self.manual_leave_para = bool(
-            context.get_node_data("Fight_ManualLeave")["enabled"]
-        )
-        logger.info(f"手动结算：{self.manual_leave_para}")
+        self.manual_leave_para = context.get_node_data("Fight_ManualLeave")[
+            "recognition"
+        ]["param"]["expected"][0]
+        logger.info(f"结算方式：{self.manual_leave_para}")
         # initialize
         self.initialize(context)
         logger.info(f"本次任务目标层数: {self.target_leave_layer_para}")
@@ -609,7 +609,7 @@ class Mars101(CustomAction):
         logger.info(f"马尔斯探索结束，当前到达{self.layers}层")
 
         # 手动结算·暂离
-        if self.manual_leave_para:
+        if self.manual_leave_para in ["清怪暂离", "九柱暂离"]:
             time.sleep(1)
             context.run_task("Save_Status")
             send_message(

--- a/agent/action/mars/mars_settlement.py
+++ b/agent/action/mars/mars_settlement.py
@@ -19,7 +19,7 @@ class MarsSettlementManager:
     def handle_before_leave_maze_event(self, context: Context):
         logger.info("触发Mars结算事件")
         context.run_task("Fight_ReturnMainWindow")
-        if not self.mars.manual_leave_para:
+        if self.mars.manual_leave_para != "清怪暂离":
             # 名导心得相关
             if self.mars.director_para:
                 fightUtils.openBagAndUseItem(
@@ -138,7 +138,7 @@ class MarsSettlementManager:
                     ):
                         break
         else:
-            logger.info("需要手动结算")
+            logger.info("需要手动结算，不放柱子直接暂离")
         # 压血相关
         # # 这里进夹层压血
         # if self.mars.target_earthgate_para >= 0:

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -284,7 +284,7 @@
                 "目标大地数量",
                 "开启自动拾取",
                 "魔法系冈布奥选择",
-                "是否手动结算",
+                "结算方式",
                 "是否启用手记开启恶魔系称号"
             ],
             "pipeline_override": {
@@ -909,23 +909,30 @@
                 }
             ]
         },
-        "是否手动结算": {
-            "type": "switch",
-            "default_case": "No",
+        "结算方式": {
+            "default_case": "自动结算",
             "cases": [
                 {
-                    "name": "No",
+                    "name": "自动结算",
                     "pipeline_override": {
                         "Fight_ManualLeave": {
-                            "enabled": false
+                            "expected": "自动结算"
                         }
                     }
                 },
                 {
-                    "name": "Yes",
+                    "name": "九柱暂离",
                     "pipeline_override": {
                         "Fight_ManualLeave": {
-                            "enabled": true
+                            "expected": "九柱暂离"
+                        }
+                    }
+                },
+                {
+                    "name": "清怪暂离",
+                    "pipeline_override": {
+                        "Fight_ManualLeave": {
+                            "expected": "清怪暂离"
                         }
                     }
                 }

--- a/assets/resource/base/pipeline/fight/fight.json
+++ b/assets/resource/base/pipeline/fight/fight.json
@@ -784,6 +784,7 @@
         "timeout": 3000
     },
     "Fight_ManualLeave": {
-        "enabled": false
+        "recognition": "OCR",
+        "expected": "false"
     }
 }


### PR DESCRIPTION
Mars手动结算开关调整为结算方式选择框，支持自动结算/九柱暂离/清怪暂离，按需选择即可。

## Summary by Sourcery

Add configurable Mars settlement modes and adjust battle flow based on the selected mode.

New Features:
- Introduce a Mars settlement mode selector that supports automatic settlement, nine-pillar temporary leave, and clear-monsters temporary leave.

Enhancements:
- Adjust Mars exploration end and settlement handling logic to branch based on the selected settlement mode instead of a simple manual-settlement toggle.
- Update logging messages to reflect the chosen settlement mode and clarify behavior when manual settlement without pillar placement is required.