### PR TITLE
refactor: 抽离时空域部分函数为外域公共函数类 foreignDomainUtils

### DIFF
--- a/agent/action/fight/foreignDomainUtils.py
+++ b/agent/action/fight/foreignDomainUtils.py
@@ -1,0 +1,204 @@
+from typing import TYPE_CHECKING
+
+from maa.context import Context
+from maa.custom_action import CustomAction
+
+from utils import logger
+
+import time
+
+if TYPE_CHECKING:
+    from action.fight.timeSpaceDomain import TSD_explore
+
+
+class foreignDomainUtils:
+    def __init__(self, TSD: "TSD_explore"):
+
+        # 舰队状态roi列表
+        self.fleetRoiList: dict = {
+            "奥鲁维": [130, 199, 60, 51],
+            "卡纳斯": [227, 200, 63, 50],
+            "游荡者": [327, 200, 64, 49],
+            "深渊": [425, 199, 64, 53],
+        }
+        self.default_fleets = ["奥鲁维", "卡纳斯", "游荡者", "深渊"]  # 默认舰队顺序
+        self.TSD: "TSD_explore" = TSD
+        self.check = False  # 是否从右下角开始检查
+        self.direction = "Left"  # 移动方向
+        self.isUp = False  # 是否上移过一次
+
+    # 检查舰队状态，是否都是空闲
+    def checkAllFleetStatus(self, context: Context) -> int:
+        img = context.tasker.controller.post_screencap().wait().get()
+        fleetStatus = context.run_recognition(
+            "checkAllFleetStatus",
+            img,
+            pipeline_override={
+                "checkAllFleetStatus": {
+                    "recognition": "TemplateMatch",
+                    "template": "fight/time_space_domain/fleetFree.png",
+                    "roi": [109, 182, 397, 95],
+                    "threshold": 0.8,
+                }
+            },
+        )
+        if fleetStatus.hit:
+            return len(fleetStatus.filtered_results)
+        else:
+            return 0
+
+    # 返回所有舰队
+    def returnFleets(self, context: Context) -> bool | CustomAction.RunResult:
+        while True:
+            if context.tasker.stopping:
+                logger.info("检测到停止任务, 开始退出agent")
+                return CustomAction.RunResult(success=False)
+            img = context.tasker.controller.post_screencap().wait().get()
+            for key in self.TSD.fleetRoiList:
+                status = context.run_recognition(
+                    "TSD_checkFreeFleet",
+                    img,
+                    pipeline_override={
+                        "TSD_checkFreeFleet": {"roi": self.TSD.fleetRoiList[key]}
+                    },
+                )
+                if not status.hit:
+                    time.sleep(1)
+                    logger.info(f"正在返回{key}舰队")
+                    context.run_task(
+                        "TSD_ClickFleet",
+                        pipeline_override={
+                            "TSD_ClickFleet": {"target": self.TSD.fleetRoiList[key]}
+                        },
+                    )
+                    context.run_task(
+                        "TSD_ReturnFleet",
+                        pipeline_override={
+                            "TSD_checkTargetFleetFree": {
+                                "roi": self.TSD.fleetRoiList[key]
+                            },
+                            "TSD_View": {
+                                "next": [
+                                    "TSD_EndExploit",
+                                    "[JumpBack]TSD_WithdrawFleet",
+                                    "[JumpBack]TSD_EndExplore",
+                                    "[JumpBack]BackText",
+                                ],
+                            },
+                        },
+                    )
+                    time.sleep(1)
+                else:
+                    logger.info(f"{key}舰队已返回,无需操作")
+            if nums := self.checkAllFleetStatus(context) == 4:
+                logger.info("所有舰队已返回")
+
+                break
+        return True
+
+    # 关闭联盟聊天窗口
+    def closeUnionMsgBox(self, context: Context) -> bool:
+        img = context.tasker.controller.post_screencap().wait().get()
+        opened = context.run_recognition(
+            "checkUnionMsgBox",
+            img,
+            pipeline_override={
+                "checkUnionMsgBox": {
+                    "recognition": "TemplateMatch",
+                    "template": "fight/time_space_domain/unionMsgOpened.png",
+                    "roi": [91, 1042, 80, 80],
+                    "threshold": 0.8,
+                }
+            },
+        )
+        if opened.hit:
+            context.run_task("TSD_closeUnionMsgBox")
+            logger.info("关闭联盟聊天窗口")
+        else:
+            logger.info("联盟聊天窗口未打开")
+        return True
+
+    # 检查地图边界
+    def checkBoundary(self, context: Context, direction: str) -> bool:
+        boundaryRoiDict: dict = {
+            "LeftTop": [12, 268, 137, 147],
+            "RightTop": [549, 276, 161, 147],
+            "Right": [597, 272, 96, 871],
+            "Left": [14, 275, 116, 766],
+            "RightBottom": [590, 1052, 117, 102],
+            "LeftBottom": [9, 1011, 145, 125],
+        }
+        img = context.tasker.controller.post_screencap().wait().get()
+        boundaryList = context.run_recognition(
+            "GridCheckTargetBoundary",
+            img,
+            pipeline_override={
+                "GridCheckTargetBoundary": {
+                    "recognition": "TemplateMatch",
+                    "template": f"fight/time_space_domain/boundary{direction}.png",
+                    "roi": boundaryRoiDict[direction],
+                    "threshold": 0.92,
+                }
+            },
+        )
+        if boundaryList.hit:
+            return True
+        return False
+
+    def swipeMapToLeftTop(self, context: Context):
+        while True:  # 将地图移动至左上角
+            if context.tasker.stopping:
+                logger.info("检测到停止任务, 开始退出agent")
+                return CustomAction.RunResult(success=False)
+            if self.checkBoundary(context, "LeftTop"):
+                break
+            else:
+                context.run_task("FD_SwipeMapMiddleToTopLeft")
+            time.sleep(1)
+        self.direction = "Right"
+        self.isUp = False
+        time.sleep(1)
+
+    def swipeMapToBottomRight(self, context: Context):
+        for _ in range(4):
+            context.run_task("FD_SwipeMapMiddleToBottomRight")
+            time.sleep(1)
+        self.direction = "Left"
+        self.isUp = False
+        time.sleep(1)
+
+    def swipeMap(self, context: Context) -> bool:
+        if self.checkBoundary(context, self.direction):
+            logger.info(f"地图{self.direction}边界")
+            if self.checkBoundary(context, "LeftTop"):
+                logger.info("已到达地图边界")
+                if self.check:
+                    self.check = False
+                    return False
+                else:
+                    # 返回地图左上角重新检查一遍
+                    self.check = True
+                    self.swipeMapToBottomRight(context)
+            elif not self.isUp:  # 未达到左上角，地图上移一次
+                logger.info("地图上移")
+                context.run_task("FD_SwipeMapToUp")
+                self.direction = "Left" if self.direction == "Right" else "Right"
+                self.isUp = True
+                time.sleep(1)
+            else:  # 已经上移过一次，按direction移动一次
+                logger.info("地图移动")
+                if self.direction == "Right":
+                    context.run_task("FD_SwipeMapToRight")
+                else:
+                    context.run_task("FD_SwipeMapToLeft")
+                self.isUp = False
+                time.sleep(1)
+        else:  # 未达到边界，地图按当前direction继续移动一次
+            logger.info("地图移动")
+            if self.direction == "Right":
+                context.run_task("FD_SwipeMapToRight")
+            else:
+                context.run_task("FD_SwipeMapToLeft")
+            self.isUp = False
+            time.sleep(2)
+        return True

--- a/agent/action/fight/foreignDomainUtils.py
+++ b/agent/action/fight/foreignDomainUtils.py
@@ -90,7 +90,7 @@ class foreignDomainUtils:
                     time.sleep(1)
                 else:
                     logger.info(f"{key}舰队已返回,无需操作")
-            if nums := self.checkAllFleetStatus(context) == 4:
+            if self.checkAllFleetStatus(context) == 4:
                 logger.info("所有舰队已返回")
 
                 break

--- a/agent/action/fight/timeSpaceDomain.py
+++ b/agent/action/fight/timeSpaceDomain.py
@@ -4,6 +4,7 @@ from maa.custom_action import CustomAction
 
 from utils import logger, send_message
 from action.fight import fightUtils
+from action.fight.foreignDomainUtils import foreignDomainUtils
 
 import time
 import json
@@ -15,25 +16,17 @@ class TSD_explore(CustomAction):
     def __init__(self):
         super().__init__()
 
-        # 舰队状态roi列表
-        self.fleetRoiList: dict = {
-            "奥鲁维": [130, 199, 60, 51],
-            "卡纳斯": [227, 200, 63, 50],
-            "游荡者": [327, 200, 64, 49],
-            "深渊": [425, 199, 64, 53],
-        }
-
         self.powerList: dict = {}  # 舰队战力
         self.highestFleet = ""  # 最高战力舰队
         self.exploreNums = 1  # 剩余需要探索的次数
         self.fleet_nums = 4  # 默认出战舰队数量
-        self.default_fleets = ["奥鲁维", "卡纳斯", "游荡者", "深渊"]  # 默认舰队顺序
         self.fight_fleets = []  # 根据选择的舰队数量按战力大小排列的舰队列表
         self.fleet_list = []  # 当前可用的舰队列表
-        self.check = False  # 是否从右下角开始检查
-        self.direction = "Left"  # 移动方向
-        self.isUp = False  # 是否上移过一次
         self.planetList: list = []  # 记录探索的星球
+
+        self.FDUtils = foreignDomainUtils(self)
+        self.fleetRoiList = self.FDUtils.fleetRoiList  # 舰队状态roi列表
+        self.default_fleets = self.FDUtils.default_fleets  # 默认舰队顺序
 
     # 获取舰队战力值
     def getAllFleetPower(self, context: Context) -> bool:
@@ -70,73 +63,6 @@ class TSD_explore(CustomAction):
         self.fight_fleets = list(powerList.keys())[: self.fleet_nums]
         self.highestFleet = self.fight_fleets[0] if self.fight_fleets else ""
 
-    # 检查舰队状态，是否都是空闲
-    def checkAllFleetStatus(self, context: Context) -> int:
-        img = context.tasker.controller.post_screencap().wait().get()
-        fleetStatus = context.run_recognition(
-            "checkAllFleetStatus",
-            img,
-            pipeline_override={
-                "checkAllFleetStatus": {
-                    "recognition": "TemplateMatch",
-                    "template": "fight/time_space_domain/fleetFree.png",
-                    "roi": [109, 182, 397, 95],
-                    "threshold": 0.8,
-                }
-            },
-        )
-        if fleetStatus.hit:
-            return len(fleetStatus.filtered_results)
-        else:
-            return 0
-
-    # 返回所有舰队
-    def returnFleets(self, context: Context) -> bool | CustomAction.RunResult:
-        while True:
-            if context.tasker.stopping:
-                logger.info("检测到停止任务, 开始退出agent")
-                return CustomAction.RunResult(success=False)
-            img = context.tasker.controller.post_screencap().wait().get()
-            for key in self.fleetRoiList:
-                status = context.run_recognition(
-                    "TSD_checkFreeFleet",
-                    img,
-                    pipeline_override={
-                        "TSD_checkFreeFleet": {"roi": self.fleetRoiList[key]}
-                    },
-                )
-                if not status.hit:
-                    time.sleep(1)
-                    logger.info(f"正在返回{key}舰队")
-                    context.run_task(
-                        "TSD_ClickFleet",
-                        pipeline_override={
-                            "TSD_ClickFleet": {"target": self.fleetRoiList[key]}
-                        },
-                    )
-                    context.run_task(
-                        "TSD_ReturnFleet",
-                        pipeline_override={
-                            "TSD_checkTargetFleetFree": {"roi": self.fleetRoiList[key]},
-                            "TSD_View": {
-                                "next": [
-                                    "TSD_EndExploit",
-                                    "[JumpBack]TSD_WithdrawFleet",
-                                    "[JumpBack]TSD_EndExplore",
-                                    "[JumpBack]BackText",
-                                ],
-                            },
-                        },
-                    )
-                    time.sleep(1)
-                else:
-                    logger.info(f"{key}舰队已返回,无需操作")
-            if nums := self.checkAllFleetStatus(context) == 4:
-                logger.info("所有舰队已返回")
-
-                break
-        return True
-
     # 获取当前屏幕的探索目标
     def GetTaskTargetList(self, context: Context, taskType: str, threshold: float):
         TargetTemplate: dict = {
@@ -165,7 +91,7 @@ class TSD_explore(CustomAction):
         )
         if exploreList.hit:
             self.exploreNums = len(exploreList.filtered_results)
-            self.check = False  # 存在目标，需要在运行到左上角时从右下角开始检查
+            self.FDUtils.check = False  # 存在目标，需要在运行到左上角时从右下角开始检查
             return exploreList.filtered_results
         else:
             self.exploreNums = 0
@@ -256,32 +182,6 @@ class TSD_explore(CustomAction):
             time.sleep(1)
         return True
 
-    def checkBoundary(self, context: Context, direction: str) -> bool:
-        boundaryRoiDict: dict = {
-            "LeftTop": [12, 268, 137, 147],
-            "RightTop": [549, 276, 161, 147],
-            "Right": [597, 272, 96, 871],
-            "Left": [14, 275, 116, 766],
-            "RightBottom": [590, 1052, 117, 102],
-            "LeftBottom": [9, 1011, 145, 125],
-        }
-        img = context.tasker.controller.post_screencap().wait().get()
-        boundaryList = context.run_recognition(
-            "GridCheckTargetBoundary",
-            img,
-            pipeline_override={
-                "GridCheckTargetBoundary": {
-                    "recognition": "TemplateMatch",
-                    "template": f"fight/time_space_domain/boundary{direction}.png",
-                    "roi": boundaryRoiDict[direction],
-                    "threshold": 0.92,
-                }
-            },
-        )
-        if boundaryList.hit:
-            return True
-        return False
-
     def checkClickTarget(self, context: Context, target: list) -> bool:
         targetList = context.run_recognition(
             "checkClickTarget",
@@ -299,64 +199,6 @@ class TSD_explore(CustomAction):
             return True
         return False
 
-    def swipeMapToLeftTop(self, context: Context):
-        while True:  # 将地图移动至左上角
-            if context.tasker.stopping:
-                logger.info("检测到停止任务, 开始退出agent")
-                return CustomAction.RunResult(success=False)
-            if self.checkBoundary(context, "LeftTop"):
-                break
-            else:
-                context.run_task("FD_SwipeMapMiddleToTopLeft")
-            time.sleep(1)
-        self.direction = "Right"
-        self.isUp = False
-        time.sleep(1)
-
-    def swipeMapToBottomRight(self, context: Context):
-        for _ in range(4):
-            context.run_task("FD_SwipeMapMiddleToBottomRight")
-            time.sleep(1)
-        self.direction = "Left"
-        self.isUp = False
-        time.sleep(1)
-
-    def swipeMap(self, context: Context) -> bool:
-        if self.checkBoundary(context, self.direction):
-            logger.info(f"地图{self.direction}边界")
-            if self.checkBoundary(context, "LeftTop"):
-                logger.info("已到达地图边界")
-                if self.check:
-                    self.check = False
-                    return False
-                else:
-                    # 返回地图左上角重新检查一遍
-                    self.check = True
-                    self.swipeMapToBottomRight(context)
-            elif not self.isUp:  # 未达到左上角，地图上移一次
-                logger.info("地图上移")
-                context.run_task("FD_SwipeMapToUp")
-                self.direction = "Left" if self.direction == "Right" else "Right"
-                self.isUp = True
-                time.sleep(1)
-            else:  # 已经上移过一次，按direction移动一次
-                logger.info("地图移动")
-                if self.direction == "Right":
-                    context.run_task("FD_SwipeMapToRight")
-                else:
-                    context.run_task("FD_SwipeMapToLeft")
-                self.isUp = False
-                time.sleep(1)
-        else:  # 未达到边界，地图按当前direction继续移动一次
-            logger.info("地图移动")
-            if self.direction == "Right":
-                context.run_task("FD_SwipeMapToRight")
-            else:
-                context.run_task("FD_SwipeMapToLeft")
-            self.isUp = False
-            time.sleep(2)
-        return True
-
     # 检测目标是否还存在
     def checkTargetExist(
         self, context: Context, taskType: str, threshold: float
@@ -364,7 +206,7 @@ class TSD_explore(CustomAction):
 
         if taskType in ["monster_boss", "planet"]:
             # 这两个任务直接可以从右下角开始检测
-            self.swipeMapToBottomRight(context)
+            self.FDUtils.swipeMapToBottomRight(context)
 
         flag = True
         # 检查是否存在目标
@@ -374,7 +216,9 @@ class TSD_explore(CustomAction):
                 return CustomAction.RunResult(success=False)
             targetList = self.GetTaskTargetList(context, taskType, threshold)
             if self.exploreNums > 0:
-                self.check = False  # 存在目标，到达地图边界就需要再次从左上角开始检查
+                self.FDUtils.check = (
+                    False  # 存在目标，到达地图边界就需要再次从右下角开始检查
+                )
                 if taskType == "planet":
                     time.sleep(1)
                     if len(self.planetList) < 4:
@@ -404,7 +248,7 @@ class TSD_explore(CustomAction):
                                 if self.exploreNums == 0:
                                     logger.info(f"该星球已发现过且已无小怪，请继续探索")
                                     context.run_task("BackText")  # 返回地图并移动
-                                    self.swipeMap(context)
+                                    self.FDUtils.swipeMap(context)
                                 else:
                                     # 该星球已发现过，但是仍有怪物未清除
                                     flag = False
@@ -416,7 +260,7 @@ class TSD_explore(CustomAction):
                                     self.planetList.append(
                                         planetName.filtered_results[0].text
                                     )
-                                    self.swipeMap(context)
+                                    self.FDUtils.swipeMap(context)
                                 else:
                                     logger.info("发现新星球")
                                     flag = False
@@ -431,33 +275,12 @@ class TSD_explore(CustomAction):
             else:
                 logger.info(f"未找到探索目标，将移动地图再次搜索")
                 if (
-                    self.swipeMap(context) == False
+                    self.FDUtils.swipeMap(context) == False
                 ):  # 已经完整探索一遍未发现目标，结束任务
                     flag = False
                     return False
                 else:
-                    self.swipeMap(context)
-        return True
-
-    def closeUnionMsgBox(self, context: Context) -> bool:
-        img = context.tasker.controller.post_screencap().wait().get()
-        opened = context.run_recognition(
-            "checkUnionMsgBox",
-            img,
-            pipeline_override={
-                "checkUnionMsgBox": {
-                    "recognition": "TemplateMatch",
-                    "template": "fight/time_space_domain/unionMsgOpened.png",
-                    "roi": [91, 1042, 80, 80],
-                    "threshold": 0.8,
-                }
-            },
-        )
-        if opened.hit:
-            context.run_task("TSD_closeUnionMsgBox")
-            logger.info("关闭联盟聊天窗口")
-        else:
-            logger.info("联盟聊天窗口未打开")
+                    self.FDUtils.swipeMap(context)
         return True
 
     def run(
@@ -493,7 +316,7 @@ class TSD_explore(CustomAction):
         context.run_task("ClickCenterBelow_500ms")
 
         # 先关闭联盟聊天窗口，避免干扰
-        self.closeUnionMsgBox(context)
+        self.FDUtils.closeUnionMsgBox(context)
 
         # 获取所有舰队战力
         self.getAllFleetPower(context)
@@ -503,7 +326,7 @@ class TSD_explore(CustomAction):
         logger.info(f"选择出战舰队列表：{ self.fight_fleets }")
 
         # 所有舰队返回
-        self.returnFleets(context)
+        self.FDUtils.returnFleets(context)
 
         # # 开始探索
         for key in taskList:

--- a/agent/agent_allfile.py
+++ b/agent/agent_allfile.py
@@ -1,6 +1,7 @@
 from action.fight import jjc101
 from action.fight import getKeyFromHole
 from action.fight import timeSpaceDomain
+from action.fight import foreignDomainUtils
 from action.activity import kairo_maze1
 from action.activity import eastern
 


### PR DESCRIPTION
refactor: 抽离时空域部分函数为外域公共函数类 foreignDomainUtils

## Summary by Sourcery

Extract shared time-space domain fleet and map utilities into a new foreignDomainUtils helper and update the TSD_explore action to use it.

Enhancements:
- Introduce foreignDomainUtils helper to encapsulate fleet ROI definitions, default fleet ordering, map scanning state, and related utility methods.
- Refactor TSD_explore to delegate fleet return handling, map navigation, and union chat window management to foreignDomainUtils for reuse and separation of concerns.