### PR TITLE
修改mars出图和mars学习巨龙称号逻辑

### DIFF
--- a/agent/action/mars/mars_title.py
+++ b/agent/action/mars/mars_title.py
@@ -93,6 +93,8 @@ class MarsTitleManager:
                 self.isGetDragonTitle = True
                 fightUtils.title_learn("巨龙", 1, "亚龙血统", 3, context)
                 fightUtils.title_learn("巨龙", 2, "初级龙族血统", 3, context)
+                fightUtils.title_learn("巨龙", 3, "中级龙族血统", 3, context)
+                fightUtils.title_learn("巨龙", 4, "高级龙族血统", 3, context)
 
             context.run_task("Fight_ReturnMainWindow")
 

--- a/agent/action/mars/mars_title.py
+++ b/agent/action/mars/mars_title.py
@@ -89,7 +89,9 @@ class MarsTitleManager:
                 fightUtils.title_learn_branch("恶魔", 5, "生命强化", 3, context)
             else:
                 logger.info("没点恶魔")
-            if fightUtils.title_check("巨龙", context):
+            if self.mars.target_leave_layer_para >= 149 and fightUtils.title_check(
+                "巨龙", context
+            ):
                 self.isGetDragonTitle = True
                 fightUtils.title_learn("巨龙", 1, "亚龙血统", 3, context)
                 fightUtils.title_learn("巨龙", 2, "初级龙族血统", 3, context)

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -930,6 +930,14 @@
                             "expected": "149"
                         }
                     }
+                },
+                {
+                    "name": "159",
+                    "pipeline_override": {
+                        "Mars_Target_Layer_Setting": {
+                            "expected": "159"
+                        }
+                    }
                 }
             ]
         },


### PR DESCRIPTION
1.繁星挂证后,吃满奖励为60/4 = 150层,增加了出图选项
2.修改了巨龙称号,不出图也先点到4级

## Summary by Sourcery

New Features:
- Enable automatic learning of level 3 and 4 dragon bloodline titles when the dragon title is obtained.